### PR TITLE
OverlayLayout for easy widget alignment in parent with uneven padding support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .classpath
 .project
 *.iml

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -131,6 +131,47 @@ public class OverlayLayout extends Layout
         return elem;
     }
 
+    /**
+     * Stretches {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T stretched (T elem) {
+        elem.setConstraint(new Constraint(ZERO, true, true, HAlign.CENTER, VAlign.CENTER));
+        return elem;
+    }
+
+    /**
+     * Configures the inter-element padding, in pixels.
+     */
+    public OverlayLayout padding (float padding) {
+        _topPadding = padding;
+        _rightPadding = padding;
+        _bottomPadding = padding;
+        _leftPadding = padding;
+        return this;
+    }
+
+    /**
+     * Configures the inter-element horizontal and vertical margins, in pixels.
+     */
+    public OverlayLayout padding (float hpadding, float vpadding) {
+        _topPadding = vpadding;
+        _rightPadding = hpadding;
+        _bottomPadding = vpadding;
+        _leftPadding = hpadding;
+        return this;
+    }
+
+    /**
+     * Configures the inter-element margins, in pixels.
+     */
+    public OverlayLayout padding (float top, float right, float bottom, float left) {
+        _topPadding = top;
+        _rightPadding = right;
+        _bottomPadding = bottom;
+        _leftPadding = left;
+        return this;
+    }
+
     @Override public Dimension computeSize (Container<?> elems, float hintX, float hintY) {
         // report a size large enough to contain all of our elements
         Rectangle bounds = new Rectangle();
@@ -158,6 +199,11 @@ public class OverlayLayout extends Layout
         return (Constraint) Asserts.checkNotNull(
             elem.constraint(), "Elements in OverlayLayout must have a constraint.");
     }
+
+    protected float _topPadding = 0.0f;
+    protected float _rightPadding = 0.0f;
+    protected float _bottomPadding = 0.0f;
+    protected float _leftPadding = 0.0f;
 
     protected static final Dimension ZERO = new Dimension(0, 0);
 }

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -31,14 +31,17 @@ public class OverlayLayout extends Layout
      */
     public static final class Constraint extends Layout.Constraint
     {
-        public final IPoint position;
         public final IDimension size;
+        public final boolean hstretch;
+        public final boolean vstretch;
         public final HAlign halign;
         public final VAlign valign;
 
-        public Constraint (IPoint position, IDimension size, HAlign halign, VAlign valign) {
-            this.position = position;
+        public Constraint (IDimension size, boolean hstretch, boolean vstretch, HAlign halign,
+            VAlign valign) {
             this.size = size;
+            this.hstretch = hstretch;
+            this.vstretch = vstretch;
             this.halign = halign;
             this.valign = valign;
         }
@@ -46,98 +49,75 @@ public class OverlayLayout extends Layout
         public IDimension psize (OverlayLayout layout, Element<?> elem) {
             float fwidth = size.width(), fheight = size.height();
             if (fwidth > 0 && fheight > 0) { return size; }
-            // if eiher forced width or height is zero, use preferred size in that dimension
+            // if either forced width or height is zero, use preferred size in that dimension
             IDimension psize = layout.preferredSize(elem, fwidth, fheight);
-            if (fwidth > 0) { return new Dimension(fwidth, psize.height()); } else if (fheight >
-                0) { return new Dimension(psize.width(), fheight); } else {
-                return psize;
-            }
+            if (fwidth > 0) return new Dimension(fwidth, psize.height());
+            else if (fheight > 0) return new Dimension(psize.width(), fheight);
+            else return psize;
         }
 
         public IPoint pos (IDimension psize) {
             return new Point(
-                position.x() + halign.offset(psize.width(), 0),
-                position.y() + valign.offset(psize.height(), 0));
+                halign.offset(psize.width(), 0),
+                valign.offset(psize.height(), 0));
         }
     }
 
     /**
-     * Positions {@code elem} at the specified position, in its preferred size.
+     * Positions {@code elem} to the parent center with the given horizontal and vertical
+     * stretching.
      */
-    public static <T extends Element<?>> T at (T elem, float x, float y) {
-        return at(elem, new Point(x, y));
+    public static <T extends Element<?>> T at (T elem, boolean hstretch, boolean vstretch) {
+        return at(elem, ZERO, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER);
     }
 
     /**
-     * Positions {@code elem} at the specified position, in its preferred size.
+     * Positions {@code elem} to the specified alignment relative to the parent.
      */
-    public static <T extends Element<?>> T at (T elem, IPoint position) {
-        return at(elem, position, ZERO);
+    public static <T extends Element<?>> T at (T elem, HAlign halign, VAlign valign) {
+        return at(elem, ZERO, false, false, halign, valign);
     }
 
     /**
-     * Constrains {@code elem} to the specified position and size.
+     * Positions {@code elem} to specified alignment relative to the parent and with specified
+     * horizontal and vertical stretching.
      */
-    public static <T extends Element<?>> T at (T elem, float x, float y, float width,
-        float height) {
-        return at(elem, new Point(x, y), new Dimension(width, height));
+    public static <T extends Element<?>> T at (T elem, boolean hstretch, boolean vstretch,
+        HAlign halign, VAlign valign) {
+        return at(elem, ZERO, hstretch, vstretch, halign, valign);
     }
 
     /**
-     * Constrains {@code elem} to the specified position and size.
+     * Constrains {@code elem} to the specified alignment relative to the parent and with specified
+     * horizontal and vertical stretching and element size.
      */
-    public static <T extends Element<?>> T at (T elem, IPoint position, IDimension size) {
-        elem.setConstraint(new Constraint(position, size, HAlign.LEFT, VAlign.TOP));
+    public static <T extends Element<?>> T at (T elem, float width, float height, boolean hstretch,
+        boolean vstretch, HAlign halign, VAlign valign) {
+        return at(elem, new Dimension(width, height), hstretch, vstretch, halign, valign);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified alignment relative to the parent and with specified
+     * horizontal and vertical stretching and element size.
+     */
+    public static <T extends Element<?>> T at (T elem, IDimension size, boolean hstretch,
+        boolean vstretch, HAlign halign, VAlign valign) {
+        elem.setConstraint(new Constraint(size, hstretch, vstretch, halign, valign));
         return elem;
     }
 
     /**
-     * Positions {@code elem} relative to the given position using the given alignments.
+     * Centers {@code elem} in the parent.
      */
-    public static <T extends Element<?>> T at (T elem, float x, float y,
-        HAlign halign, VAlign valign) {
-        return at(elem, new Point(x, y), ZERO, halign, valign);
+    public static <T extends Element<?>> T center (T elem) {
+        return center(elem, false, false);
     }
 
     /**
-     * Positions {@code elem} relative to the given position using the given alignments.
+     * Centers {@code elem} in the parent with specified horizontal and vertical stretching.
      */
-    public static <T extends Element<?>> T at (T elem, IPoint position,
-        HAlign halign, VAlign valign) {
-        return at(elem, position, ZERO, halign, valign);
-    }
-
-    /**
-     * Constrains {@code elem} to the specified size and aligns it relative to the given position
-     * using the given alignments.
-     */
-    public static <T extends Element<?>> T at (T elem, float x, float y, float width, float height,
-        HAlign halign, VAlign valign) {
-        return at(elem, new Point(x, y), new Dimension(width, height), halign, valign);
-    }
-
-    /**
-     * Constrains {@code elem} to the specified size and aligns it relative to the given position
-     * using the given alignments.
-     */
-    public static <T extends Element<?>> T at (T elem, IPoint position, IDimension size,
-        HAlign halign, VAlign valign) {
-        elem.setConstraint(new Constraint(position, size, halign, valign));
-        return elem;
-    }
-
-    /**
-     * Centers {@code elem} on the specified position, in its preferred size.
-     */
-    public static <T extends Element<?>> T centerAt (T elem, float x, float y) {
-        return centerAt(elem, new Point(x, y));
-    }
-
-    /**
-     * Centers {@code elem} on the specified position, in its preferred size.
-     */
-    public static <T extends Element<?>> T centerAt (T elem, IPoint position) {
-        elem.setConstraint(new Constraint(position, ZERO, HAlign.CENTER, VAlign.CENTER));
+    public static <T extends Element<?>> T center (T elem, boolean hstretch, boolean vstretch) {
+        elem.setConstraint(new Constraint(ZERO, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER));
         return elem;
     }
 

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -81,6 +81,24 @@ public class OverlayLayout extends Layout
 
     /**
      * Constrains {@code elem} to the specified alignment relative to the parent and with specified
+     * size.
+     */
+    public static <T extends Element<?>> T at (T elem, float width, float height, HAlign halign,
+        VAlign valign) {
+        return at(elem, new Dimension(width, height), false, false, halign, valign);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified alignment relative to the parent and with specified
+     * size.
+     */
+    public static <T extends Element<?>> T at (T elem, IDimension size, HAlign halign,
+        VAlign valign) {
+        return at(elem, size, false, false, halign, valign);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified alignment relative to the parent and with specified
      * horizontal and vertical stretching and element size.
      */
     public static <T extends Element<?>> T at (T elem, float width, float height, boolean hstretch,

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -1,0 +1,173 @@
+package tripleplay.ui.layout;
+
+import playn.core.Asserts;
+
+import pythagoras.f.Dimension;
+import pythagoras.f.IDimension;
+import pythagoras.f.IPoint;
+import pythagoras.f.Point;
+import pythagoras.f.Rectangle;
+
+import tripleplay.ui.Container;
+import tripleplay.ui.Element;
+import tripleplay.ui.Layout;
+import tripleplay.ui.Style.HAlign;
+import tripleplay.ui.Style.VAlign;
+
+/**
+ * A layout that positions elements at above each other with different stretching and alignment
+ * constraints. Constraints are specified like so:
+ * <pre>{@code
+ * Group group = new Group(new OverlayLayout()).add(
+ *     OverlayLayout.at(new Label("+50+50"), 50, 50),
+ *     OverlayLayout.at(new Button("100x50+25+25"), 25, 25, 100, 50)
+ * );
+ * }</pre>
+ */
+public class OverlayLayout extends Layout
+{
+    /**
+     * Defines overlay layout constraints.
+     */
+    public static final class Constraint extends Layout.Constraint
+    {
+        public final IPoint position;
+        public final IDimension size;
+        public final HAlign halign;
+        public final VAlign valign;
+
+        public Constraint (IPoint position, IDimension size, HAlign halign, VAlign valign) {
+            this.position = position;
+            this.size = size;
+            this.halign = halign;
+            this.valign = valign;
+        }
+
+        public IDimension psize (OverlayLayout layout, Element<?> elem) {
+            float fwidth = size.width(), fheight = size.height();
+            if (fwidth > 0 && fheight > 0) { return size; }
+            // if eiher forced width or height is zero, use preferred size in that dimension
+            IDimension psize = layout.preferredSize(elem, fwidth, fheight);
+            if (fwidth > 0) { return new Dimension(fwidth, psize.height()); } else if (fheight >
+                0) { return new Dimension(psize.width(), fheight); } else {
+                return psize;
+            }
+        }
+
+        public IPoint pos (IDimension psize) {
+            return new Point(
+                position.x() + halign.offset(psize.width(), 0),
+                position.y() + valign.offset(psize.height(), 0));
+        }
+    }
+
+    /**
+     * Positions {@code elem} at the specified position, in its preferred size.
+     */
+    public static <T extends Element<?>> T at (T elem, float x, float y) {
+        return at(elem, new Point(x, y));
+    }
+
+    /**
+     * Positions {@code elem} at the specified position, in its preferred size.
+     */
+    public static <T extends Element<?>> T at (T elem, IPoint position) {
+        return at(elem, position, ZERO);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified position and size.
+     */
+    public static <T extends Element<?>> T at (T elem, float x, float y, float width,
+        float height) {
+        return at(elem, new Point(x, y), new Dimension(width, height));
+    }
+
+    /**
+     * Constrains {@code elem} to the specified position and size.
+     */
+    public static <T extends Element<?>> T at (T elem, IPoint position, IDimension size) {
+        elem.setConstraint(new Constraint(position, size, HAlign.LEFT, VAlign.TOP));
+        return elem;
+    }
+
+    /**
+     * Positions {@code elem} relative to the given position using the given alignments.
+     */
+    public static <T extends Element<?>> T at (T elem, float x, float y,
+        HAlign halign, VAlign valign) {
+        return at(elem, new Point(x, y), ZERO, halign, valign);
+    }
+
+    /**
+     * Positions {@code elem} relative to the given position using the given alignments.
+     */
+    public static <T extends Element<?>> T at (T elem, IPoint position,
+        HAlign halign, VAlign valign) {
+        return at(elem, position, ZERO, halign, valign);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified size and aligns it relative to the given position
+     * using the given alignments.
+     */
+    public static <T extends Element<?>> T at (T elem, float x, float y, float width, float height,
+        HAlign halign, VAlign valign) {
+        return at(elem, new Point(x, y), new Dimension(width, height), halign, valign);
+    }
+
+    /**
+     * Constrains {@code elem} to the specified size and aligns it relative to the given position
+     * using the given alignments.
+     */
+    public static <T extends Element<?>> T at (T elem, IPoint position, IDimension size,
+        HAlign halign, VAlign valign) {
+        elem.setConstraint(new Constraint(position, size, halign, valign));
+        return elem;
+    }
+
+    /**
+     * Centers {@code elem} on the specified position, in its preferred size.
+     */
+    public static <T extends Element<?>> T centerAt (T elem, float x, float y) {
+        return centerAt(elem, new Point(x, y));
+    }
+
+    /**
+     * Centers {@code elem} on the specified position, in its preferred size.
+     */
+    public static <T extends Element<?>> T centerAt (T elem, IPoint position) {
+        elem.setConstraint(new Constraint(position, ZERO, HAlign.CENTER, VAlign.CENTER));
+        return elem;
+    }
+
+    @Override public Dimension computeSize (Container<?> elems, float hintX, float hintY) {
+        // report a size large enough to contain all of our elements
+        Rectangle bounds = new Rectangle();
+        for (Element<?> elem : elems) {
+            if (!elem.isVisible()) { continue; }
+            Constraint c = constraint(elem);
+            IDimension psize = c.psize(this, elem);
+            bounds.add(new Rectangle(c.pos(psize), psize));
+        }
+        return new Dimension(bounds.width, bounds.height);
+    }
+
+    @Override public void layout (Container<?> elems,
+        float left, float top, float width, float height) {
+        for (Element<?> elem : elems) {
+            if (!elem.isVisible()) { continue; }
+            Constraint c = constraint(elem);
+            IDimension psize = c.psize(this, elem); // this should return a cached size
+            IPoint pos = c.pos(psize);
+            setBounds(elem, left + pos.x(), top + pos.y(), psize.width(), psize.height());
+        }
+    }
+
+    protected static Constraint constraint (Element<?> elem) {
+        return (Constraint) Asserts.checkNotNull(
+            elem.constraint(), "Elements in OverlayLayout must have a constraint.");
+    }
+
+    protected static final Dimension ZERO = new Dimension(0, 0);
+}

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -64,14 +64,6 @@ public class OverlayLayout extends Layout
     }
 
     /**
-     * Positions {@code elem} to the parent center with the given horizontal and vertical
-     * stretching.
-     */
-    public static <T extends Element<?>> T at (T elem, boolean hstretch, boolean vstretch) {
-        return at(elem, ZERO, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER);
-    }
-
-    /**
      * Positions {@code elem} to the specified alignment relative to the parent.
      */
     public static <T extends Element<?>> T at (T elem, HAlign halign, VAlign valign) {
@@ -117,7 +109,25 @@ public class OverlayLayout extends Layout
      * Centers {@code elem} in the parent with specified horizontal and vertical stretching.
      */
     public static <T extends Element<?>> T center (T elem, boolean hstretch, boolean vstretch) {
-        elem.setConstraint(new Constraint(ZERO, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER));
+        return center(elem, ZERO, hstretch, vstretch);
+    }
+
+    /**
+     * Centers {@code elem} in the parent with specified horizontal and vertical stretching and
+     * element size.
+     */
+    public static <T extends Element<?>> T center (T elem, float width, float height,
+        boolean hstretch, boolean vstretch) {
+        return center(elem, new Dimension(width, height), hstretch, vstretch);
+    }
+
+    /**
+     * Centers {@code elem} in the parent with specified horizontal and vertical stretching and
+     * element size.
+     */
+    public static <T extends Element<?>> T center (T elem, IDimension size, boolean hstretch,
+        boolean vstretch) {
+        elem.setConstraint(new Constraint(size, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER));
         return elem;
     }
 
@@ -133,8 +143,8 @@ public class OverlayLayout extends Layout
         return new Dimension(bounds.width, bounds.height);
     }
 
-    @Override public void layout (Container<?> elems,
-        float left, float top, float width, float height) {
+    @Override public void layout (Container<?> elems, float left, float top, float width,
+        float height) {
         for (Element<?> elem : elems) {
             if (!elem.isVisible()) { continue; }
             Constraint c = constraint(elem);

--- a/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
+++ b/core/src/main/java/tripleplay/ui/layout/OverlayLayout.java
@@ -46,9 +46,12 @@ public class OverlayLayout extends Layout
             this.valign = valign;
         }
 
-        public IDimension psize (OverlayLayout layout, Element<?> elem) {
+        public IDimension psize (OverlayLayout layout, Element<?> elem, float availX,
+            float availY) {
             float fwidth = size.width(), fheight = size.height();
-            if (fwidth > 0 && fheight > 0) { return size; }
+            if (hstretch) fwidth = availX;
+            if (vstretch) fheight = availY;
+            if (fwidth > 0 && fheight > 0) return new Dimension(fwidth, fheight);
             // if either forced width or height is zero, use preferred size in that dimension
             IDimension psize = layout.preferredSize(elem, fwidth, fheight);
             if (fwidth > 0) return new Dimension(fwidth, psize.height());
@@ -56,10 +59,10 @@ public class OverlayLayout extends Layout
             else return psize;
         }
 
-        public IPoint pos (IDimension psize) {
+        public IPoint pos (IDimension psize, float availX, float availY) {
             return new Point(
-                halign.offset(psize.width(), 0),
-                valign.offset(psize.height(), 0));
+                halign.offset(psize.width(), availX),
+                valign.offset(psize.height(), availY));
         }
     }
 
@@ -145,16 +148,218 @@ public class OverlayLayout extends Layout
      */
     public static <T extends Element<?>> T center (T elem, IDimension size, boolean hstretch,
         boolean vstretch) {
-        elem.setConstraint(new Constraint(size, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER));
-        return elem;
+        return at(elem, size, hstretch, vstretch, HAlign.CENTER, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the left {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T centerLeft (T elem) {
+        return at(elem, ZERO, false, false, HAlign.LEFT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the left {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerLeft (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.LEFT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the left {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerLeft (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.LEFT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the right {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T centerRight (T elem) {
+        return at(elem, ZERO, false, false, HAlign.RIGHT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the right {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerRight (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.RIGHT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers vertically and aligns to the right {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerRight (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.RIGHT, VAlign.CENTER);
+    }
+
+    /**
+     * Centers horizontally and aligns to the top {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T centerTop (T elem) {
+        return at(elem, ZERO, false, false, HAlign.CENTER, VAlign.TOP);
+    }
+
+    /**
+     * Centers horizontally and aligns to the top {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerTop (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.CENTER, VAlign.TOP);
+    }
+
+    /**
+     * Centers horizontally and aligns to the top {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerTop (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.CENTER, VAlign.TOP);
+    }
+
+    /**
+     * Centers horizontally and aligns to the bottom {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T centerBottom (T elem) {
+        return at(elem, ZERO, false, false, HAlign.CENTER, VAlign.BOTTOM);
+    }
+
+    /**
+     * Centers horizontally and aligns to the bottom {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerBottom (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.CENTER, VAlign.BOTTOM);
+    }
+
+    /**
+     * Centers horizontally and aligns to the bottom {@code elem} in the parent with specified
+     * element size.
+     */
+    public static <T extends Element<?>> T centerBottom (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.CENTER, VAlign.BOTTOM);
     }
 
     /**
      * Stretches {@code elem} in the parent.
      */
-    public static <T extends Element<?>> T stretched (T elem) {
-        elem.setConstraint(new Constraint(ZERO, true, true, HAlign.CENTER, VAlign.CENTER));
-        return elem;
+    public static <T extends Element<?>> T stretch (T elem) {
+        return at(elem, ZERO, true, true, HAlign.CENTER, VAlign.CENTER);
+    }
+
+    /**
+     * Stretches and aligns to the right the {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T stretchRight (T elem) {
+        return at(elem, ZERO, false, true, HAlign.RIGHT, VAlign.CENTER);
+    }
+
+    /**
+     * Stretches and aligns to the left the {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T stretchLeft (T elem) {
+        return at(elem, ZERO, false, true, HAlign.LEFT, VAlign.CENTER);
+    }
+
+    /**
+     * Stretches and aligns to the top the {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T stretchTop (T elem) {
+        return at(elem, ZERO, true, false, HAlign.CENTER, VAlign.TOP);
+    }
+
+    /**
+     * Stretches and aligns to the bottom the {@code elem} in the parent.
+     */
+    public static <T extends Element<?>> T stretchBottom (T elem) {
+        return at(elem, ZERO, true, false, HAlign.CENTER, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-left corner in the parent.
+     */
+    public static <T extends Element<?>> T topLeft (T elem) {
+        return at(elem, ZERO, false, false, HAlign.LEFT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-left corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T topLeft (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.LEFT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-left corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T topLeft (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.LEFT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-right corner in the parent.
+     */
+    public static <T extends Element<?>> T topRight (T elem) {
+        return at(elem, ZERO, false, false, HAlign.RIGHT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-right corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T topRight (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.RIGHT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the top-right corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T topRight (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.RIGHT, VAlign.TOP);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-left corner in the parent.
+     */
+    public static <T extends Element<?>> T bottomLeft (T elem) {
+        return at(elem, ZERO, false, false, HAlign.LEFT, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-left corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T bottomLeft (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.LEFT, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-left corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T bottomLeft (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.LEFT, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-right corner in the parent.
+     */
+    public static <T extends Element<?>> T bottomRight (T elem) {
+        return at(elem, ZERO, false, false, HAlign.RIGHT, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-right corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T bottomRight (T elem, float width, float height) {
+        return at(elem, new Dimension(width, height), false, false, HAlign.RIGHT, VAlign.BOTTOM);
+    }
+
+    /**
+     * Aligns {@code elem} to the bottom-right corner in the parent with specified element size.
+     */
+    public static <T extends Element<?>> T bottomRight (T elem, IDimension size) {
+        return at(elem, size, false, false, HAlign.RIGHT, VAlign.BOTTOM);
     }
 
     /**
@@ -191,25 +396,34 @@ public class OverlayLayout extends Layout
     }
 
     @Override public Dimension computeSize (Container<?> elems, float hintX, float hintY) {
+        // available size without paddings
+        float availX = hintX - _leftPadding - _rightPadding;
+        float availY = hintY - _topPadding - _bottomPadding;
+
         // report a size large enough to contain all of our elements
         Rectangle bounds = new Rectangle();
         for (Element<?> elem : elems) {
-            if (!elem.isVisible()) { continue; }
+            if (!elem.isVisible()) continue;
             Constraint c = constraint(elem);
-            IDimension psize = c.psize(this, elem);
-            bounds.add(new Rectangle(c.pos(psize), psize));
+            IDimension psize = c.psize(this, elem, availX, availY);
+            bounds.add(new Rectangle(c.pos(psize, availX, availY), psize));
         }
         return new Dimension(bounds.width, bounds.height);
     }
 
     @Override public void layout (Container<?> elems, float left, float top, float width,
         float height) {
+        // available size without paddings
+        float availX = width - _leftPadding - _rightPadding;
+        float availY = height - _topPadding - _bottomPadding;
+
         for (Element<?> elem : elems) {
-            if (!elem.isVisible()) { continue; }
+            if (!elem.isVisible()) continue;
             Constraint c = constraint(elem);
-            IDimension psize = c.psize(this, elem); // this should return a cached size
-            IPoint pos = c.pos(psize);
-            setBounds(elem, left + pos.x(), top + pos.y(), psize.width(), psize.height());
+            IDimension psize = c.psize(this, elem, availX, availY); // this should return a cached size
+            IPoint pos = c.pos(psize, availX, availY);
+            setBounds(elem, _leftPadding + left + pos.x(), _topPadding + top + pos.y(),
+                psize.width(), psize.height());
         }
     }
 

--- a/demo/core/src/main/java/tripleplay/demo/DemoMenuScreen.java
+++ b/demo/core/src/main/java/tripleplay/demo/DemoMenuScreen.java
@@ -48,7 +48,7 @@ public class DemoMenuScreen extends UIScreen
             // tripleplay.ui
             new MiscDemo(), new LabelDemo(), new SliderDemo(),
             new BackgroundDemo(), new LayoutDemo(), new BorderLayoutDemo(),
-            new FlowLayoutDemo(), new SelectorDemo(), new MenuDemo(),
+            new FlowLayoutDemo(), new OverlayLayoutDemo(), new SelectorDemo(), new MenuDemo(),
             new ScrollerDemo(), new TabsDemo(), new TableLayoutDemo(),
             // tripleplay.anim
             new FramesDemo(), new AnimDemo(), new FlickerDemo(),

--- a/demo/core/src/main/java/tripleplay/demo/DemoMenuScreen.java
+++ b/demo/core/src/main/java/tripleplay/demo/DemoMenuScreen.java
@@ -36,7 +36,7 @@ public class DemoMenuScreen extends UIScreen
     public DemoMenuScreen (ScreenStack stack) {
         _stack = stack;
         _rlabels = new String[] {
-            "tripleplay.ui", "", "", "",
+            "tripleplay.ui", "", "", "", "",
             "tripleplay.anim",
             "tripleplay.game",
             "tripleplay.entity",
@@ -48,8 +48,9 @@ public class DemoMenuScreen extends UIScreen
             // tripleplay.ui
             new MiscDemo(), new LabelDemo(), new SliderDemo(),
             new BackgroundDemo(), new LayoutDemo(), new BorderLayoutDemo(),
-            new FlowLayoutDemo(), new OverlayLayoutDemo(), new SelectorDemo(), new MenuDemo(),
-            new ScrollerDemo(), new TabsDemo(), new TableLayoutDemo(),
+            new FlowLayoutDemo(), new OverlayLayoutDemo(), new SelectorDemo(),
+            new MenuDemo(), new ScrollerDemo(), new TabsDemo(),
+            new TableLayoutDemo(), null, null,
             // tripleplay.anim
             new FramesDemo(), new AnimDemo(), new FlickerDemo(),
             // tripleplay.game

--- a/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
@@ -1,0 +1,44 @@
+//
+// Triple Play - utilities for use in PlayN-based games
+// Copyright (c) 2011-2013, Three Rings Design, Inc. - All rights reserved.
+// http://github.com/threerings/tripleplay/blob/master/LICENSE
+
+package tripleplay.demo.ui;
+
+import pythagoras.f.Dimension;
+import pythagoras.f.Point;
+
+import tripleplay.demo.DemoScreen;
+import tripleplay.ui.*;
+import tripleplay.ui.layout.AxisLayout;
+import tripleplay.ui.layout.OverlayLayout;
+
+public class OverlayLayoutDemo extends DemoScreen
+{
+    @Override protected String name () {
+        return "OverlayLayout";
+    }
+
+    @Override protected String title () {
+        return "UI: OverlayLayout";
+    }
+
+    @Override protected Group createIface () {
+        Group root = new Group(AxisLayout.vertical().offStretch()).setConstraint(AxisLayout.stretched());
+
+        Group panel = new Group(new OverlayLayout(), Styles.make(Style.BACKGROUND.is(
+            Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
+        panel.add(newSection("first", new OverlayLayout.Constraint(new Point(100.0f, 50.0f),
+            new Dimension(200.0f, 100.0f), Style.HAlign.CENTER, Style.VAlign.CENTER), 0xFFFFFF00));
+
+        root.add(panel.setConstraint(AxisLayout.stretched()));
+        return root;
+    }
+
+    protected Element<?> newSection (String text, OverlayLayout.Constraint constraint, int bgColor) {
+        Background colorBg = Background.solid(bgColor).inset(5);
+        Element<?> e = new Label(text).addStyles(Style.BACKGROUND.is(colorBg)).
+            setConstraint(constraint);
+        return e;
+    }
+}

--- a/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
@@ -25,19 +25,17 @@ public class OverlayLayoutDemo extends DemoScreen
     @Override protected Group createIface () {
         Group root = new Group(AxisLayout.vertical().offStretch()).setConstraint(AxisLayout.stretched());
 
-        Group panel = new Group(new OverlayLayout(), Styles.make(Style.BACKGROUND.is(
-            Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
-        panel.add(newSection("first", new OverlayLayout.Constraint(new Dimension(200.0f, 100.0f),
-            false, false, Style.HAlign.CENTER, Style.VAlign.CENTER), 0xFFFFFF00));
+        Group panel = new Group(new OverlayLayout().padding(10.0f, 15.0f, 20.0f, 25.0f),
+            Styles.make(Style.BACKGROUND.is(Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
+        panel.add(OverlayLayout.stretched(newSection("background", 0xFFFF0000)));
+        panel.add(OverlayLayout.center(newSection("first", 0xFFFFFF00)));
 
         root.add(panel.setConstraint(AxisLayout.stretched()));
         return root;
     }
 
-    protected Element<?> newSection (String text, OverlayLayout.Constraint constraint, int bgColor) {
+    protected Element<?> newSection (String text, int bgColor) {
         Background colorBg = Background.solid(bgColor).inset(5);
-        Element<?> e = new Label(text).addStyles(Style.BACKGROUND.is(colorBg)).
-            setConstraint(constraint);
-        return e;
+        return new Label(text).addStyles(Style.BACKGROUND.is(colorBg));
     }
 }

--- a/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
@@ -27,8 +27,14 @@ public class OverlayLayoutDemo extends DemoScreen
 
         Group panel = new Group(new OverlayLayout().padding(10.0f, 15.0f, 20.0f, 25.0f),
             Styles.make(Style.BACKGROUND.is(Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
-        panel.add(OverlayLayout.stretched(newSection("background", 0xFFFF0000)));
-        panel.add(OverlayLayout.center(newSection("first", 0xFFFFFF00)));
+        panel.add(OverlayLayout.stretched(newSection("Background", 0xFFFF0000)));
+        panel.add(OverlayLayout.center(newSection("Centered", 0xFFFFFF00)));
+        panel.add(OverlayLayout.at(newSection("Center/Right", 0xFF00FF00), 100.0f, 75.0f,
+            Style.HAlign.RIGHT, Style.VAlign.CENTER));
+        panel.add(OverlayLayout.at(newSection("Stretched/Right", 0xFF0000FF), false, true,
+            Style.HAlign.RIGHT, Style.VAlign.CENTER));
+        panel.add(OverlayLayout.at(newSection("Bottom/Left", 0xFF00FFFF), Style.HAlign.LEFT,
+            Style.VAlign.BOTTOM));
 
         root.add(panel.setConstraint(AxisLayout.stretched()));
         return root;

--- a/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
@@ -5,8 +5,6 @@
 
 package tripleplay.demo.ui;
 
-import pythagoras.f.Dimension;
-
 import tripleplay.demo.DemoScreen;
 import tripleplay.ui.*;
 import tripleplay.ui.layout.AxisLayout;
@@ -26,15 +24,18 @@ public class OverlayLayoutDemo extends DemoScreen
         Group root = new Group(AxisLayout.vertical().offStretch()).setConstraint(AxisLayout.stretched());
 
         Group panel = new Group(new OverlayLayout().padding(10.0f, 15.0f, 20.0f, 25.0f),
-            Styles.make(Style.BACKGROUND.is(Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
-        panel.add(OverlayLayout.stretched(newSection("Background", 0xFFFF0000)));
+            Styles.make(Style.BACKGROUND.is(Background.bordered(0xFFFFFFFF, 0xFF000000, 2))));
+        panel.add(OverlayLayout.stretch(newSection("Stretched", 0xFFFF0000)
+            .addStyles(Style.VALIGN.bottom)));
         panel.add(OverlayLayout.center(newSection("Centered", 0xFFFFFF00)));
-        panel.add(OverlayLayout.at(newSection("Center/Right", 0xFF00FF00), 100.0f, 75.0f,
-            Style.HAlign.RIGHT, Style.VAlign.CENTER));
-        panel.add(OverlayLayout.at(newSection("Stretched/Right", 0xFF0000FF), false, true,
-            Style.HAlign.RIGHT, Style.VAlign.CENTER));
-        panel.add(OverlayLayout.at(newSection("Bottom/Left", 0xFF00FFFF), Style.HAlign.LEFT,
-            Style.VAlign.BOTTOM));
+        panel.add(OverlayLayout.stretchTop(newSection("Stretched/Top", 0xFFFF00FF)));
+        panel.add(OverlayLayout.stretchRight(newSection("Stretched/Right", 0xFF0000FF))
+            .addStyles(Style.VALIGN.bottom));
+        panel.add(OverlayLayout.centerLeft(newSection("Center/Left", 0xFF00FF00)));
+        panel.add(OverlayLayout.centerRight(newSection("Center/Right", 0xFF00FF00), 120.0f, 75.0f));
+        panel.add(OverlayLayout.topLeft(newSection("Top/Left", 0xFF00FFFF)));
+        panel.add(OverlayLayout.topRight(newSection("Top/Right", 0xFF00FFFF)));
+        panel.add(OverlayLayout.bottomLeft(newSection("Bottom/Left", 0xFF00FFFF), 150.0f, 100.0f));
 
         root.add(panel.setConstraint(AxisLayout.stretched()));
         return root;

--- a/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/OverlayLayoutDemo.java
@@ -6,7 +6,6 @@
 package tripleplay.demo.ui;
 
 import pythagoras.f.Dimension;
-import pythagoras.f.Point;
 
 import tripleplay.demo.DemoScreen;
 import tripleplay.ui.*;
@@ -28,8 +27,8 @@ public class OverlayLayoutDemo extends DemoScreen
 
         Group panel = new Group(new OverlayLayout(), Styles.make(Style.BACKGROUND.is(
             Background.bordered(0xFFFFFFFF, 0xff000000, 2).inset(4))));
-        panel.add(newSection("first", new OverlayLayout.Constraint(new Point(100.0f, 50.0f),
-            new Dimension(200.0f, 100.0f), Style.HAlign.CENTER, Style.VAlign.CENTER), 0xFFFFFF00));
+        panel.add(newSection("first", new OverlayLayout.Constraint(new Dimension(200.0f, 100.0f),
+            false, false, Style.HAlign.CENTER, Style.VAlign.CENTER), 0xFFFFFF00));
 
         root.add(panel.setConstraint(AxisLayout.stretched()));
         return root;

--- a/demo/java/pom.xml
+++ b/demo/java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-demo</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.8</version>
   </parent>
 
   <artifactId>tripleplay-demo-java</artifactId>


### PR DESCRIPTION
Here is a new UI layout that allows to align multiple overlaying children inside the parent. This can be used similarly as a FrameLayout in Android. It also supports setting an uneven content padding globally for all children. Maybe it would be better if padding would be property of child constraints to allow different paddings for different childrens but this is not implemented yet. Do you see such feature resonable?

There is also a new OverlayLayout demo in the demo screen menu to try it out:

![overlay_layout](https://f.cloud.github.com/assets/23485/1839090/c918507c-7470-11e3-8025-27e6c329f8dc.png)
