### PR TITLE
Layers.capture doesn't respect images alpha value

### DIFF
--- a/core/src/main/java/tripleplay/util/Layers.java
+++ b/core/src/main/java/tripleplay/util/Layers.java
@@ -152,10 +152,11 @@ public class Layers
 
         } else if (layer instanceof ImageLayer) {
             ImageLayer il = (ImageLayer)layer;
+            canvas.setAlpha(il.alpha());
             canvas.drawImage(il.image(), 0, 0);
         } else if (layer instanceof ImmediateLayer) {
             ImmediateLayer il = (ImmediateLayer)layer;
-            il.renderer().render(new CanvasSurface(canvas));
+            il.renderer().render(new CanvasSurface(canvas).setAlpha(il.alpha()));
         }
 
         canvas.restore();


### PR DESCRIPTION
When capturing a layer, it renders the sub-layers full opaque, even if they have an alpha value != 1

I didn't test this fully, I'm not sure if (or how to) I have to restore the alpha to the current value, something like

```
float oldAlpha = canvas.alpha(); // method doesn't exist
canvas.setAlpha(il.alpha());
canvas.drawImage(il.image(), 0, 0);
canvas.setAlpha(oldAlpha);
```
