### PR TITLE
make captured root's children interactive

### DIFF
--- a/core/src/main/java/tripleplay/ui/CapturedRoot.java
+++ b/core/src/main/java/tripleplay/ui/CapturedRoot.java
@@ -8,7 +8,9 @@ package tripleplay.ui;
 import playn.core.Canvas;
 import playn.core.CanvasImage;
 import playn.core.ImageLayer;
+import playn.core.Layer;
 import pythagoras.f.Dimension;
+import pythagoras.f.Point;
 import react.Connection;
 import react.Slot;
 import react.Value;
@@ -71,6 +73,16 @@ public class CapturedRoot extends Root
      * displaying the root's image on its layer.
      */
     protected class Embedded extends Widget<Embedded> {
+
+        protected Embedded() {
+            layer.setHitTester(new Layer.HitTester() {
+                @Override public Layer hitTest(Layer layer, Point point) {
+                    return CapturedRoot.this.layer.hitTest(point);
+                }
+            });
+            layer.setInteractive(true);
+        }
+
         @Override protected Class<?> getStyleClass () {
             return Embedded.class;
         }

--- a/demo/core/src/main/java/tripleplay/demo/ui/MiscDemo.java
+++ b/demo/core/src/main/java/tripleplay/demo/ui/MiscDemo.java
@@ -91,8 +91,10 @@ public class MiscDemo extends DemoScreen
                 setField = new Button("Set -> "),
                 disabled = new Field("Disabled text").setEnabled(false)));
 
-        capRoot.add(new Label("Captured Root!").addStyles(
-            Style.BACKGROUND.is(Background.blank().inset(10)))).pack();
+        capRoot.add(new Group(AxisLayout.vertical())
+                        .addStyles(Style.BACKGROUND.is(Background.blank().inset(10)))
+                        .add(new Label("Captured Root!"), new Button("Captured Button"))
+                ).pack();
 
         // add a style animation to the captured root (clicking on cap roots NYI)
         this.iface.animator().repeat(_root.layer).delay(1000).then().action(new Runnable() {


### PR DESCRIPTION
CapturedRoot's  GroupLayer does not have parent, so all the children of the root is not interactive. This commit fix it.
