### PR TITLE
Demo fixes

### DIFF
--- a/demo/android/pom.xml
+++ b/demo/android/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-demo</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>tripleplay-demo-android</artifactId>

--- a/demo/html/pom.xml
+++ b/demo/html/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-demo</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>tripleplay-demo-html</artifactId>

--- a/demo/ios/pom.xml
+++ b/demo/ios/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-demo</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>tripleplay-demo-ios</artifactId>

--- a/demo/java/pom.xml
+++ b/demo/java/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-demo</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>tripleplay-demo-java</artifactId>

--- a/demo/java/pom.xml
+++ b/demo/java/pom.xml
@@ -30,7 +30,7 @@
 
     <dependency>
       <groupId>com.threerings</groupId>
-      <artifactId>tripleplay-java-lwjgl</artifactId>
+      <artifactId>tripleplay-java-lwjgl2</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/demo/java/pom.xml
+++ b/demo/java/pom.xml
@@ -52,13 +52,7 @@
             <phase>test</phase>
             <configuration>
               <target>
-                <!-- these shenanigans are needed to pass -XstartOnFirstThread on Mac OS
-                     but not on other OSes where they would cause the JVM to fail, yay -->
-                <condition property="jvmarg" value="-XstartOnFirstThread" else="-Dfoo=bar">
-                  <os family="mac" />
-                </condition>
                 <java fork="true" classname="${mainClass}" classpathref="maven.test.classpath">
-                  <jvmarg value="${jvmarg}" />
                   <arg value="${testIndex}" />
                 </java>
               </target>

--- a/ios/pom.xml
+++ b/ios/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.threerings</groupId>
     <artifactId>tripleplay-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>tripleplay-ios</artifactId>


### PR DESCRIPTION
When trying to run the java demos, I stumbled across some problems.

With this PR, `mvn -Pjava test` should work again.

I am not so sure about removing the `-XstartOnFirstThread` parameter. I don't have a java7 around anymore to verify if the java version really makes the difference. But it seems that this parameter must not be used anymore: With it I get a red and black flickering window.