### PR TITLE
Fix bug with computed size when hintX is 0

### DIFF
--- a/core/src/main/java/tripleplay/ui/TextWidget.java
+++ b/core/src/main/java/tripleplay/ui/TextWidget.java
@@ -127,7 +127,7 @@ public abstract class TextWidget<T extends TextWidget<T>> extends Widget<T>
         }
 
         @Override public Dimension computeSize (float hintX, float hintY) {
-            if (text != null && (autoShrink || ellipsize)) {
+            if (hintX > 0 && text != null && (autoShrink || ellipsize)) {
                 float availWidth = hintX;
                 if (icon != null && iconPos.horizontal()) availWidth -= icon.width() + iconGap;
                 maybeShrinkOrEllipsize(availWidth);


### PR DESCRIPTION
When computing size, hintX == 0 means that the available width is
not known. In this case do not try to ellipsize or shrink the text.