### PR TITLE
Box.set(el) should remove element from its parent.

### DIFF
--- a/core/src/main/java/tripleplay/ui/Box.java
+++ b/core/src/main/java/tripleplay/ui/Box.java
@@ -266,6 +266,7 @@ public class Box extends Container.Mutable<Box> {
         }
         _contents = contents;
         if (contents != null) {
+            removeFromParent(contents, false);
             didAdd(contents);
         }
         invalidate();


### PR DESCRIPTION
Before this fix, the following sequence:

```
box1.set(foo);
box2.set(foo);
box1.set(bar);
```

results in an exception ("Could not remove Layer because it is not a child of the GroupLayer...")
