### PR TITLE
Translate pointer event coordinates to screen coordinates.

### DIFF
--- a/core/src/main/java/tripleplay/ui/util/XYFlicker.java
+++ b/core/src/main/java/tripleplay/ui/util/XYFlicker.java
@@ -11,6 +11,8 @@ import pythagoras.f.Point;
 import react.Signal;
 
 import playn.scene.Pointer;
+import playn.scene.Layer;
+import playn.scene.LayerUtil;
 
 /**
  * Translates pointer input on a layer into an x, y offset. With a sufficiently large drag delta,
@@ -70,6 +72,7 @@ public class XYFlicker extends Pointer.Listener
         _cur.set(_start);
         _prevStamp = 0;
         _curStamp = iact.event.time;
+        _layer = iact.hitLayer;
     }
 
     @Override public void onDrag (Pointer.Interaction iact) {
@@ -155,6 +158,7 @@ public class XYFlicker extends Pointer.Listener
     /** Translates a pointer event into a position. */
     protected void getPosition (Pointer.Event event, Point dest) {
         dest.set(-event.x(), -event.y());
+        LayerUtil.layerToScreen(_layer, dest, dest);
     }
 
     /** Sets the current position, clamping the values between min and max. */
@@ -179,4 +183,5 @@ public class XYFlicker extends Pointer.Listener
     protected final Point _start = new Point(), _cur = new Point(), _prev = new Point();
     protected final Point _max = new Point(), _min = new Point();
     protected double _prevStamp, _curStamp;
+    protected Layer _layer;
 }

--- a/core/src/main/java/tripleplay/ui/util/XYFlicker.java
+++ b/core/src/main/java/tripleplay/ui/util/XYFlicker.java
@@ -67,7 +67,7 @@ public class XYFlicker extends Pointer.Listener
         _vel.set(0, 0);
         _maxDeltaSq = 0;
         _origPos.set(_position);
-        getPosition(iact.event, _start);
+        getPosition(iact, _start);
         _prev.set(_start);
         _cur.set(_start);
         _prevStamp = 0;
@@ -78,7 +78,7 @@ public class XYFlicker extends Pointer.Listener
     @Override public void onDrag (Pointer.Interaction iact) {
         _prev.set(_cur);
         _prevStamp = _curStamp;
-        getPosition(iact.event, _cur);
+        getPosition(iact, _cur);
         _curStamp = iact.event.time;
         float dx = _cur.x - _start.x, dy = _cur.y - _start.y;
         setPosition(_origPos.x + dx, _origPos.y + dy);
@@ -156,9 +156,8 @@ public class XYFlicker extends Pointer.Listener
     }
 
     /** Translates a pointer event into a position. */
-    protected void getPosition (Pointer.Event event, Point dest) {
-        dest.set(-event.x(), -event.y());
-        LayerUtil.layerToScreen(_layer, dest, dest);
+    protected void getPosition (Pointer.Interaction iact, Point dest) {
+        dest.set(-iact.local.x, -iact.local.y);
     }
 
     /** Sets the current position, clamping the values between min and max. */


### PR DESCRIPTION
This fixes the case for layers that have transforms applied
(for example, rotations of 90, 180, 270 degrees)