### PR TITLE
setLocation(): round coords instead of truncating.

### DIFF
--- a/core/src/main/java/tripleplay/ui/Element.java
+++ b/core/src/main/java/tripleplay/ui/Element.java
@@ -473,7 +473,7 @@ public abstract class Element<T extends Element<T>>
      * Configures the location of this element, relative to its parent.
      */
     protected void setLocation (float x, float y) {
-        layer.setTranslation(MathUtil.ifloor(x), MathUtil.ifloor(y));
+        layer.setTranslation(MathUtil.round(x), MathUtil.round(y));
     }
 
     /**


### PR DESCRIPTION
This avoids visual artifacts on devices with non-integer
scaling factors.