### PR TITLE
SizableGroup: Fix not being resizable at all.

### DIFF
--- a/core/src/main/java/tripleplay/ui/SizableGroup.java
+++ b/core/src/main/java/tripleplay/ui/SizableGroup.java
@@ -5,6 +5,7 @@
 
 package tripleplay.ui;
 
+import pythagoras.f.Dimension;
 import pythagoras.f.IDimension;
 import tripleplay.util.DimensionValue;
 
@@ -36,8 +37,17 @@ public class SizableGroup extends Group
         preferredSize.connect(invalidateSlot());
     }
 
-    @Override protected LayoutData createLayoutData (float hintX, float hintY) {
-        // use a sizable layout data with the usual layout and hybrid size
-        return new SizableLayoutData(super.createLayoutData(hintX, hintY), preferredSize.get());
+    @Override
+    protected Dimension computeSize(LayoutData ldata, float hintX, float hintY) {
+        IDimension pSize = preferredSize.get();
+        float pWidth = pSize.width();
+        float pHeight = pSize.height();
+
+        Dimension size = super.computeSize(ldata, select(pWidth, hintX), select(pHeight, hintY));
+        return new Dimension(select(pWidth, size.width), select(pHeight, size.height));
+    }
+
+    private static float select (float pref, float base) {
+        return pref == 0 ? base : pref;
     }
 }


### PR DESCRIPTION
This is an attempt for fixing #84.

The previous implementation just overrides createLayoutData(float,float) to
return a SizableLayoutData instance but apparently layoutData is not taken
into account neither in:
 - Container.computeSize(LayoutData,float,float) nor in
 - Container.layout(LayoutData,float,float,float,float)
as they both delegate to Layout.

Changed the implementation to mimic the behaviour of the SizableLayoutData
instance created in the previous implementation in createLayoutData,
but using Layout.computeSize() as base instead of LayoutData.computeSize().
So we just override computeSize(LayoutData,float,float) to call super
(with adjusted hints) and then modify the result to apply the preferred size
if defined.