### PR TITLE
Fix coordinate alignment issues when sibling elements are invalidated

### DIFF
--- a/core/src/main/java/tripleplay/ui/Element.java
+++ b/core/src/main/java/tripleplay/ui/Element.java
@@ -417,21 +417,24 @@ public abstract class Element<T extends Element<T>>
      * visualizations, or laying out children, or anything else.
      */
     protected void validate () {
-        if (!isSet(Flag.VALID)) {
-            // prior to laying ourselves out, ensure that our visual boundaries fall on physical
-            // pixels; this avoids rendering artifacts on devices where the scale factor between
-            // virtual and physical pixels is non-integral
-            Root root = root();
-            if (root != null) {
-                Scale scale = root.iface.plat.graphics().scale();
-                float x = layer.tx(), y = layer.ty();
-                float rx = scale.roundToNearestPixel(x), ry = scale.roundToNearestPixel(y);
-                float rr = scale.roundToNearestPixel(x + _size.width);
-                float rb = scale.roundToNearestPixel(y + _size.height);
-                layer.setTranslation(rx, ry);
-                _size.setSize(rr-rx, rb-ry);
-            }
+        // prior to laying ourselves out, ensure that our visual boundaries fall on physical
+        // pixels; this avoids rendering artifacts on devices where the scale factor between
+        // virtual and physical pixels is non-integral.
+        // Note that this needs to be done even if we have not been invalidated, because if
+        // parents have been invalidated, layout() may have been called which may have updated
+        // our layer boundaries.
+        Root root = root();
+        if (root != null) {
+            Scale scale = root.iface.plat.graphics().scale();
+            float x = layer.tx(), y = layer.ty();
+            float rx = scale.roundToNearestPixel(x), ry = scale.roundToNearestPixel(y);
+            float rr = scale.roundToNearestPixel(x + _size.width);
+            float rb = scale.roundToNearestPixel(y + _size.height);
+            layer.setTranslation(rx, ry);
+            _size.setSize(rr-rx, rb-ry);
+        }
 
+        if (!isSet(Flag.VALID)) {
             // now that our boundaries are adjusted, we can layout our children (if any)
             layout();
             set(Flag.VALID, true);

--- a/core/src/test/java/tripleplay/ui/ElementTest.java
+++ b/core/src/test/java/tripleplay/ui/ElementTest.java
@@ -15,6 +15,7 @@ import pythagoras.f.IDimension;
 import playn.core.*;
 // import playn.java.JavaPlatform;
 import tripleplay.ui.layout.AxisLayout;
+import tripleplay.ui.layout.BorderLayout;
 
 public class ElementTest
 {
@@ -232,6 +233,7 @@ public class ElementTest
 
     private final static float PIXEL_EPSILON = .05f;
 
+    /** Tests alignment of element boundaries to physical pixel coordinates. */
     @Test public void testPixelCoordinates() {
         float factor = 1.333f;
         int nitems = 10;
@@ -263,6 +265,43 @@ public class ElementTest
                 float next  = scale.scaled(els[i + 1].x());
                 assertEquals(end + 1, next, PIXEL_EPSILON);
             }
+        }
+    }
+
+    @Test public void testPixelCoordinates2() {
+
+        ((StubGraphics) stub.graphics()).setScale(new Scale(1f));
+
+        class MyShim extends Shim {
+            MyShim() {
+                super(100, 55);
+            }
+
+            void assertCoordsAligned() {
+                float x = x(), y = y();
+                assertEquals(Math.round(x), x, PIXEL_EPSILON);
+                assertEquals(Math.round(y), y, PIXEL_EPSILON);
+            }
+        }
+
+        MyShim els[] = new MyShim[] { new MyShim(), new MyShim() };
+        Group g = new Group(AxisLayout.horizontal().gap(5)).add(els);
+
+        Root root = iface.createRoot(new BorderLayout(), Stylesheet.builder().create()).setSize(300, 100);
+        root.add(g.setConstraint(BorderLayout.CENTER)).validate();
+
+        // Check that both elements are initially aligned to physical pixel coordinates
+        for (MyShim el : els) {
+            el.assertCoordsAligned();
+        }
+
+        // Invalidate one of the elements, and trigger a revalidation
+        els[0].invalidate();
+        root.validate();
+
+        // Check that both elements are still aligned
+        for (MyShim el : els) {
+            el.assertCoordsAligned();
         }
     }
 }


### PR DESCRIPTION
Always align visual boundaries to physical pixels in validate(), even
if the element itself has not been invalidated. This fixes the case where
a sibling element is invalidated and the parent re-layouts all children,
thus updating their layer boundaries.

Also add a test case.

Fixes: #88