### PR TITLE
Fix glyph canvas layer not properly shrunk

### DIFF
--- a/core/src/main/java/tripleplay/util/Glyph.java
+++ b/core/src/main/java/tripleplay/util/Glyph.java
@@ -46,8 +46,7 @@ public class Glyph implements Closeable
             if (_depth != null) layer.setDepth(_depth);
             _parent.add(layer);
             _layer = layer;
-        } else if (layer.width() < width || layer.height() < height) {
-            // TODO: should we ever shrink it?
+        } else if (layer.width() != width || layer.height() != height) {
             layer.resize(width, height);
         }
         _preparedWidth = width;


### PR DESCRIPTION
The canvas layer held by a glyph instance is now properly shrunk when the prepared size is smaller than the current one. This avoids strange behaviours where a Button instance is re-laid out to a smaller size but the inner canvas layer for the text is not resized and overflows its parent layer.

This fixes #94 