### PR TITLE
Removed constraint assertion

### DIFF
--- a/core/src/main/java/tripleplay/ui/Element.java
+++ b/core/src/main/java/tripleplay/ui/Element.java
@@ -282,9 +282,6 @@ public abstract class Element<T extends Element<T>>
      * @return this element for call chaining.
      */
     public T setConstraint (Layout.Constraint constraint) {
-        assert (_constraint == null || constraint == null) :
-            "Cannot set constraint on element which already has a constraint. " +
-            "Layout constraints cannot be automatically composed.";
         if (constraint != null) constraint.setElement(this);
         _constraint = constraint;
         invalidate();


### PR DESCRIPTION
There seems to be some legitimate use cases for changing constraints. For example, when using AbsoluteLayout, different instances of AbsoluteLayout.Constraint may be used, to change the location of absolutely positioned elements.

Besides, the check could be easily worked around by calling setConstraint(null) before setting the new constraint, so it wasn't specially effective.

This would solve #96.