### PR TITLE
Fix URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Contact
 Questions, comments, and other worldly endeavors can be handled via the
 [Three Rings Libraries](http://groups.google.com/group/ooo-libs) Google Group.
 
-[API documentation]: http://threerings.github.com/tripleplay/apidocs/overview-summary.html
-[API changes since 2.0]: http://threerings.github.com/tripleplay/apidocs/changes
+[API documentation]: https://threerings.github.io/tripleplay/apidocs/overview-summary.html
+[API changes since 2.0]: https://threerings.github.io/tripleplay/apidocs/changes
 [GWT]: http://code.google.com/webtoolkit/
 [Maven]: http://maven.apache.org/
 [PlayN]: http://code.google.com/p/playn
 [Release Notes]: https://github.com/threerings/tripleplay/wiki/ReleaseNotes
 [SBT]: http://github.com/harrah/xsbt/wiki/Setup
-[demo of the UI toolkit]: http://threerings.github.com/tripleplay/widgetdemo.html
+[demo of the UI toolkit]: https://threerings.github.io/tripleplay/widgetdemo.html

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ Contact
 -------
 
 Questions, comments, and other worldly endeavors can be handled via the
-[Three Rings Libraries](http://groups.google.com/group/ooo-libs) Google Group.
+[Three Rings Libraries](https://groups.google.com/group/ooo-libs) Google Group.
 
 [API documentation]: https://threerings.github.io/tripleplay/apidocs/overview-summary.html
 [API changes since 2.0]: https://threerings.github.io/tripleplay/apidocs/changes
-[GWT]: http://code.google.com/webtoolkit/
-[Maven]: http://maven.apache.org/
-[PlayN]: http://code.google.com/p/playn
+[GWT]: https://www.gwtproject.org/
+[Maven]: https://maven.apache.org/
+[PlayN]: https://playn.io/
 [Release Notes]: https://github.com/threerings/tripleplay/wiki/ReleaseNotes
-[SBT]: http://github.com/harrah/xsbt/wiki/Setup
+[SBT]: https://www.scala-sbt.org/
 [demo of the UI toolkit]: https://threerings.github.io/tripleplay/widgetdemo.html


### PR DESCRIPTION
The github.com URLs have stopped working; switch those over to github.io.

While we are at it also update other URLs which have changed, and switch the remaining ones from http to https.